### PR TITLE
Fix: publish kibalitool as executable

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -207,7 +207,7 @@ stages:
         inputs:
           command: 'publish'
           arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.Graph.KibaliTool-v$(kibaliToolversion) -p:PublishTrimmed=true
-          projects: 'src/kibali/KibaliTool.csproj'
+          projects: 'src/kibali/KibaliTool/KibaliTool.csproj'
           publishWebProjects: False
           zipAfterPublish: false 
 

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -207,7 +207,7 @@ stages:
         inputs:
           command: 'publish'
           arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.Graph.KibaliTool-v$(kibaliToolversion) -p:PublishTrimmed=true
-          projects: 'src/kibali/KibaliTool/KibaliTool.csproj'
+          projects: 'src/kibaliTool/KibaliTool.csproj'
           publishWebProjects: False
           zipAfterPublish: false 
 

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -206,7 +206,7 @@ stages:
         displayName: publish kibalitool as executable
         inputs:
           command: 'publish'
-          arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.Graph.KibaliTool-v$(kibaliToolversion) -p:PublishTrimmed=true
+          arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.Graph.Kibali-v$(kibaliToolversion) -p:PublishTrimmed=true
           projects: 'src/kibaliTool/KibaliTool.csproj'
           publishWebProjects: False
           zipAfterPublish: false 


### PR DESCRIPTION
The build pipeline fails at the `publish kibalitool as executable` step because the yml file points to the wrong location