### PR TITLE
Task: Remove package filters

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -294,7 +294,7 @@ stages:
               displayName: Download nupkg from artifacts
               inputs:
                 artifact: Nugets
-                source: curren
+                source: current
             - task: NuGetCommand@2
               displayName: 'NuGet push'
               inputs:

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -294,15 +294,7 @@ stages:
               displayName: Download nupkg from artifacts
               inputs:
                 artifact: Nugets
-                source: current
-            - powershell: |
-                $fileNames = "$(Pipeline.Workspace)/Nugets/Microsoft.Graph.Kibali.*.nupkg", "$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Readers.*.nupkg", "$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Workbench.*.nupkg"
-                foreach($fileName in $fileNames) {
-                  if(Test-Path $fileName) {
-                    rm $fileName -Verbose
-                  }
-                }
-              displayName: remove other nupkgs to avoid duplication
+                source: curren
             - task: NuGetCommand@2
               displayName: 'NuGet push'
               inputs:


### PR DESCRIPTION
The `remove other nupkgs to avoid duplication` step is a legacy step brought forward from a copy of another pipeline that generates mutliple nuget packages. 

The presence of this step makes the NuGet publishing step fail because the filter removes the generated Kibali package