### PR TITLE
Update generated permission tables to have 3 columns

### DIFF
--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.5.0-preview</Version>
+    <Version>0.6.0-preview</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -228,7 +228,7 @@ namespace Kibali
 
         public string GeneratePermissionsTable(Dictionary<string, List<AcceptableClaim>> methodClaims)
         {
-            var permissionsStub = new List<string> { "**TODO: Provide applicable permissions.**" };
+            var permissionsStub = new List<string> { "Not supported." };
             var markdownBuilder = new MarkDownBuilder();
             markdownBuilder.StartTable("Permission type", "Least privileged permission", "Higher privileged permissions");
             var least = string.Empty;
@@ -253,7 +253,7 @@ namespace Kibali
         {
             var least = orderedScopes.First();
             var others = orderedScopes.Skip(1);
-            var higher = others.Any() ? string.Join(", ", others) : string.Empty;
+            var higher = others.Any() ? string.Join(", ", others) : "Not supported.";
             return (least, higher);
         }
     }

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -13,11 +13,11 @@ public class DocumentationTests
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         var expectedTable = @"
-|Permission type|Permissions (from least to most privileged)|
-|:---|:---|
-|Delegated (work or school account)|Foo.Read, Foo.ReadWrite|
-|Delegated (personal Microsoft account)|**TODO: Provide applicable permissions.**|
-|Application|Foo.ReadWrite|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+|Permission type|Least privileged permission|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Foo.Read|Foo.ReadWrite|
+|Delegated (personal Microsoft account)|**TODO: Provide applicable permissions.**||
+|Application|Foo.ReadWrite||".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         Assert.Equal(expectedTable, table);
 

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -16,8 +16,8 @@ public class DocumentationTests
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
 |Delegated (work or school account)|Foo.Read|Foo.ReadWrite|
-|Delegated (personal Microsoft account)|**TODO: Provide applicable permissions.**||
-|Application|Foo.ReadWrite||".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Foo.ReadWrite|Not supported.|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         Assert.Equal(expectedTable, table);
 


### PR DESCRIPTION
Updating the permissions table generation to move from the two columns to the three columns. The middle column will have the least privileged permission while the third column will have the higher privileged permissions.
![image](https://user-images.githubusercontent.com/1733185/223412889-e2725ed7-acc4-4142-9a4b-de694d4f6364.png)
