### PR TITLE
Generate default permissions table if resource or permissions are not found

### DIFF
--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Kibali;
+﻿namespace Kibali;
 
 public class PermissionsStubGenerator
 {
@@ -26,23 +24,33 @@ public class PermissionsStubGenerator
         authZChecker.Load(this.document);
 
         var resource = authZChecker.FindResource(this.path);
+        var table = this.UnsupportedPermissionsStub();
         if (resource == null)
         {
-            return string.Empty;
+            return table;
         }
         
-        var table = string.Empty;
         if (!string.IsNullOrEmpty(this.method))
         {
             if (resource.SupportedMethods.TryGetValue(this.method, out var supportedSchemes))
             {
                 table = resource.GeneratePermissionsTable(supportedSchemes);
             }
-            else
-            {
-                throw new ArgumentException($"Unknown method {this.method}");
-            }
         }
         return table;
+    }
+
+    private string UnsupportedPermissionsStub(){
+        var permissionsStub = "Not supported.";
+        var markdownBuilder = new MarkDownBuilder();
+        markdownBuilder.StartTable("Permission type", "Least privileged permission", "Higher privileged permissions");
+
+        markdownBuilder.AddTableRow("Delegated (work or school account)", permissionsStub, permissionsStub);
+
+        markdownBuilder.AddTableRow("Delegated (personal Microsoft account)", permissionsStub, permissionsStub);
+
+        markdownBuilder.AddTableRow("Application", permissionsStub, permissionsStub);
+        markdownBuilder.EndTable();
+        return markdownBuilder.ToString();
     }
 }

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -24,14 +24,53 @@ public class DocumentationTests
     }
 
     [Fact]
-    public void DocumentationTableNotGenerated()
+    public void DocumentationTableNotGeneratedMissingPath()
     {
         var permissionsDocument = CreatePermissionsDocument();
 
         var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/bar", "GET");
-        var table = generator.GenerateTable();
+        var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+        var expectedTable = @"
+|Permission type|Least privileged permission|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Not supported.|Not supported.|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+        Assert.Equal(expectedTable, table);
 
-        Assert.Equal(string.Empty, table);
+    }
+
+    [Fact]
+    public void DocumentationTableNotGeneratedNoMethod()
+    {
+        var permissionsDocument = CreatePermissionsDocument();
+
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", null);
+        var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+        var expectedTable = @"
+|Permission type|Least privileged permission|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Not supported.|Not supported.|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+        Assert.Equal(expectedTable, table);
+
+    }
+
+    [Fact]
+    public void DocumentationTableNotGeneratedUnsupportedMethod()
+    {
+        var permissionsDocument = CreatePermissionsDocument();
+
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", "PATCH");
+        var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+        var expectedTable = @"
+|Permission type|Least privileged permission|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Not supported.|Not supported.|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+        Assert.Equal(expectedTable, table);
 
     }
 


### PR DESCRIPTION
We need to generate the table with the boilerplate text if the path or method doesn't have permissions in the model.