### PR TITLE
Fix to allow loading of permissions from a folder if other json files exist

### DIFF
--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/PermissionsDocument.cs
+++ b/src/kibali/PermissionsDocument.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -55,9 +56,17 @@ namespace Kibali
             var mergedPermissions = new Dictionary<string, Permission>();
             foreach (var permissionsFile in Directory.EnumerateFiles(documentPath, "*.json"))
             {
-                using var stream = new FileStream(permissionsFile, FileMode.Open);
-                var doc = Load(stream);
-                mergedPermissions = mergedPermissions.Concat(doc.Permissions).ToDictionary(x => x.Key, x => x.Value);
+                try
+                {
+                    using var stream = new FileStream(permissionsFile, FileMode.Open);
+                    var doc = Load(stream);
+                    mergedPermissions = mergedPermissions.Concat(doc.Permissions).ToDictionary(x => x.Key, x => x.Value);
+                }
+                catch (KeyNotFoundException ex)
+                {
+                    Console.WriteLine($"Unable to parse json file {permissionsFile}. {ex.Message}");
+                }
+                
             }
 
             mergedDoc.Permissions = new SortedDictionary<string, Permission>(mergedPermissions);
@@ -67,9 +76,7 @@ namespace Kibali
         public static PermissionsDocument Load(JsonElement value)
         {
             var permissionsDocument = new PermissionsDocument();
-
             ParsingHelpers.ParseMap(value, permissionsDocument, handlers);
-
             return permissionsDocument;
         }
 

--- a/src/kibali/Scheme.cs
+++ b/src/kibali/Scheme.cs
@@ -11,6 +11,8 @@ namespace Kibali
         public string UserDescription { get; set; }
         public bool RequiresAdminConsent { get; set; }
 
+        public int PrivilegeLevel { get; set; }
+
         public void Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
@@ -20,9 +22,11 @@ namespace Kibali
             if (!String.IsNullOrEmpty(UserDisplayName)) writer.WriteString("userDisplayName", UserDisplayName);
             if (!String.IsNullOrEmpty(UserDescription)) writer.WriteString("userDescription", UserDescription);
             if (RequiresAdminConsent == true) writer.WriteBoolean("requiresAdminConsent", RequiresAdminConsent);
+            if (PrivilegeLevel != 0) writer.WriteNumber("privilegeLevel", PrivilegeLevel);
 
             writer.WriteEndObject();
         }
+
 
         public static Scheme Load(JsonElement value)
         {
@@ -38,6 +42,7 @@ namespace Kibali
             { "userDisplayName", (o,v) => {o.UserDisplayName = v.GetString();  } },
             { "userDescription", (o,v) => {o.UserDescription = v.GetString();  } },
             { "requiresAdminConsent", (o,v) => {o.RequiresAdminConsent = v.GetBoolean();  } },
+            { "privilegeLevel", (o,v) => {o.PrivilegeLevel = v.GetInt32();  } },
         };
     }
 

--- a/src/kibaliTool/KibaliTool.csproj
+++ b/src/kibaliTool/KibaliTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kibali</ToolCommandName>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <PackageId>Microsoft.Graph.KibaliTool</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibaliTool/KibaliTool.csproj
+++ b/src/kibaliTool/KibaliTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kibali</ToolCommandName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <PackageId>Microsoft.Graph.KibaliTool</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>


### PR DESCRIPTION
If a json file exists that doesn't match the permissions schema, we should fail gracefully, not break the entire loading process.