### PR TITLE
Update provisioning info spec to have the permission metadata as an array of objects

### DIFF
--- a/specs/permissions-deployment-schema.json
+++ b/specs/permissions-deployment-schema.json
@@ -5,32 +5,36 @@
             "type": "object",
             "patternProperties": {
                 "[\\w]+\\.[\\w]+[\\.[\\w]+]?": {
-                    "type": "object",
-                    "properties": {
-                        "id": {
-                            "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "resourceAppId": {
+                                "type": "string"
+                            },
+                            "environment": {
+                                "type": "string"
+                            },
+                            "scheme": {
+                                "type": "string"
+                            },
+                            "isHidden": {
+                                "type": "boolean"
+                            },
+                            "isDisabled": {
+                                "type": "boolean"
+                            }
                         },
-                        "resourceAppId": {
-                            "type": "string"
-                        },
-                        "environment": {
-                            "type": "string"
-                        },
-                        "scheme": {
-                            "type": "string"
-                        },
-                        "isHidden": {
-                            "type": "boolean"
-                        },
-                        "isDisabled": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": [
-                        "id",
-                        "environment",
-                        "scheme"
-                    ]
+                        "required": [
+                            "id",
+                            "environment",
+                            "scheme"
+                        ]
+                    }
+                    
                 }
             }
             

--- a/specs/permissions-schema.json
+++ b/specs/permissions-schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "title": "Schema for OAuth Permissions",
     "type": "object",
     "properties": {
@@ -29,8 +29,8 @@
                     "type": "boolean"
                 },
 
-                "provisioningInfo": {
-                    "$ref": "#/definitions/provisioningInfo"
+                "ownerInfo": {
+                    "$ref": "#/definitions/ownerInfo"
                 },
                 
                 "schemes": {
@@ -111,7 +111,7 @@
         },
         "path": {
             "type": "string",
-            "pattern": "^([\\w]+=[\\w]+;)*([\\w]+=[\\w]+)?$"
+            "pattern": "^([\\w]+=[\\w]+(?:[,.]*[\\w]*)*;)*([\\w]+=[\\w]+(?:[,.]*[\\w]+)+)?$"
         },
         "scheme": {
             "type": "object",


### PR DESCRIPTION
The existing deployments spec is invalid as per the examples we've given.
It should be:
permission name: {
   [
   object1,
   object2
  ]
}

not 
permission name: {
   object
}
so that we can add multiple metadata entries, one for each permission scheme.

Also updated the main permissions schema to have the ownerInfo object instead of the provisioningInfo object and the regex to allow multiple least privilege schemes and other entries like `alsoRequires`