### PR TITLE
Address code scanning alerts

### DIFF
--- a/src/kibali/OwnerInfo.cs
+++ b/src/kibali/OwnerInfo.cs
@@ -27,7 +27,7 @@ namespace Kibali
             return ownerInfo;
         }
 
-        private static FixedFieldMap<OwnerInfo> handlers = new()
+        private static readonly FixedFieldMap<OwnerInfo> handlers = new()
         {
             { "ownerSecurityGroup", (o,v) => { o.OwnerSecurityGroup= v.GetString(); } },
         };

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -36,12 +36,9 @@ public class PermissionsStubGenerator
             return table;
         }
         
-        if (!string.IsNullOrEmpty(this.method))
+        if (!string.IsNullOrEmpty(this.method) && resource.SupportedMethods.TryGetValue(this.method, out var supportedSchemes))
         {
-            if (resource.SupportedMethods.TryGetValue(this.method, out var supportedSchemes))
-            {
-                  table = resource.GeneratePermissionsTable(this.method, supportedSchemes);
-            }
+            table = resource.GeneratePermissionsTable(this.method, supportedSchemes);
         }
         return table;
     }

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -194,7 +194,6 @@ namespace Kibali
 
         public Dictionary<string, Dictionary<string, HashSet<string>>> FetchLeastPrivilege(string method = null, string scheme = null)
         {
-            var output = string.Empty;
             var leastPrivilege = new Dictionary<string, Dictionary<string, HashSet<string>>>();
             if (method != null && scheme != null)
             {
@@ -267,10 +266,9 @@ namespace Kibali
         private (string least, string higher) GetTableScopes(string scheme, Dictionary<string, List<AcceptableClaim>> methodClaims, Dictionary<string, HashSet<string>> leastPrivilege)
         {
             var permissionsStub = new List<string>();
-            var scopes = new HashSet<string>();
 
             var delegatedWorkScopes = methodClaims.TryGetValue(scheme, out List<AcceptableClaim> claims) ? claims.OrderByDescending(c => c.Least).Select(c => c.Permission) : permissionsStub;
-            var leastPrivilegeScheme = leastPrivilege.TryGetValue(scheme, out scopes);
+            leastPrivilege.TryGetValue(scheme, out HashSet<string> scopes);
             (var least, var higher) = ExtractScopes(delegatedWorkScopes, scopes);
             return (least, higher);
         }

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -287,14 +287,10 @@ namespace Kibali
             // If more than one permission exists as the least privilege due to grouping of the methods
             if (permissions.Count > 1)
             {
-                var exclusivePrivilegeCount = 0;
-                foreach (var perm in permissions)
-                {
-                    if ((this.PermissionMethods.TryGetValue((perm, scheme), out HashSet<string> supportedMethods) && supportedMethods.Count == 1))
-                    {
-                        exclusivePrivilegeCount++;
-                    }
-                }
+                var exclusivePrivilegeCount = permissions.Count(perm => 
+                    this.PermissionMethods.TryGetValue((perm, scheme), out HashSet<string> supportedMethods) &&
+                    supportedMethods.Count == 1);
+
                 if (exclusivePrivilegeCount > 1)
                 {
                     return permissions;

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -198,7 +198,7 @@ namespace Kibali
             if (method != null && scheme != null)
             {
                 leastPrivilege.TryAdd(method, new Dictionary<string, HashSet<string>>());
-                var permissions = this.SupportedMethods[method][scheme].Where(p => p.Least == true).Select(p => p.Permission).ToHashSet();
+                var permissions = this.SupportedMethods[method][scheme].Where(p => p.Least).Select(p => p.Permission).ToHashSet();
                 PopulateLeastPrivilege(leastPrivilege, method, scheme, permissions);
             }
             if (method != null && scheme == null)
@@ -211,7 +211,7 @@ namespace Kibali
                 foreach (var supportedScheme in supportedSchemes.OrderBy(s => Enum.Parse(typeof(SchemeType), s.Key)))
                 {
                     leastPrivilege.TryAdd(method, new Dictionary<string, HashSet<string>>());
-                    var permissions = supportedScheme.Value.Where(p => p.Least == true).Select(p => p.Permission).ToHashSet();
+                    var permissions = supportedScheme.Value.Where(p => p.Least).Select(p => p.Permission).ToHashSet();
                     PopulateLeastPrivilege(leastPrivilege, method, supportedScheme.Key, permissions);
                 }
             }
@@ -225,7 +225,7 @@ namespace Kibali
                         continue;
                     }
                     leastPrivilege.TryAdd(supportedMethod.Key, new Dictionary<string, HashSet<string>>());
-                    var permissions = supportedSchemeClaims.Where(p => p.Least == true).Select(p => p.Permission).ToHashSet();
+                    var permissions = supportedSchemeClaims.Where(p => p.Least).Select(p => p.Permission).ToHashSet();
                     PopulateLeastPrivilege(leastPrivilege, supportedMethod.Key, scheme, permissions);
                 }
             }
@@ -236,7 +236,7 @@ namespace Kibali
                     foreach (var supportedScheme in supportedMethod.Value.OrderBy(s => Enum.Parse(typeof(SchemeType), s.Key)))
                     {
                         leastPrivilege.TryAdd(supportedMethod.Key, new Dictionary<string, HashSet<string>>());
-                        var permissions = supportedScheme.Value.Where(p => p.Least == true).Select(p => p.Permission).ToHashSet();
+                        var permissions = supportedScheme.Value.Where(p => p.Least).Select(p => p.Permission).ToHashSet();
                         PopulateLeastPrivilege(leastPrivilege, supportedMethod.Key, supportedScheme.Key, permissions);
                     }
                 }

--- a/src/kibali/ProvisioningInfo.cs
+++ b/src/kibali/ProvisioningInfo.cs
@@ -43,7 +43,7 @@ namespace Kibali
             return provisioningInfo;
         }
 
-        private static FixedFieldMap<ProvisioningInfo> handlers = new()
+        private static readonly FixedFieldMap<ProvisioningInfo> handlers = new()
         {
             { "id", (o,v) => { o.Id = v.GetString(); } },
             { "scheme", (o,v) => { o.Scheme = v.GetString(); } },

--- a/src/kibaliTool/ImportCommand.cs
+++ b/src/kibaliTool/ImportCommand.cs
@@ -212,16 +212,9 @@ namespace KibaliTool
 
         private static async Task<JsonElement> FetchAndParseJsonAsync(string path, HttpClient client)
         {
-            Stream inputStream;
-
-            if (path.StartsWith("http"))
-            {
-                inputStream = await client.GetStreamAsync(path);
-            }
-            else
-            {
-                inputStream = new FileStream(path, FileMode.Open);
-            }
+            Stream inputStream = path.StartsWith("http") 
+                ? await client.GetStreamAsync(path) 
+                : new FileStream(path, FileMode.Open);
 
             using (inputStream)
             {


### PR DESCRIPTION
This PR:
- Removes useless assignment to local variable
- Marks some fields as `readonly` as necessary
- Uses ternary operator for `if-else` statement as necessary
- Combines nested if statements
- Removes unnecessarily complex Boolean expression
- Replaces `foreach` loop with `.Where` clause
- Renames method parameters to prevent confusion with class field names