### PR TITLE
Add validation to check for mismatching schemes between the pathsets and the permissions

### DIFF
--- a/src/kibali/AuthZChecker.cs
+++ b/src/kibali/AuthZChecker.cs
@@ -115,8 +115,15 @@ namespace Kibali
             {
                 var provisioningData = new List<ProvisioningInfo>();
                 this.PermissionsDeployment?.Deployments?.TryGetValue(permission.Key, out provisioningData);
+                var permissionSchemes = permission.Value.Schemes.Keys;
                 foreach (var pathSet in permission.Value.PathSets)
                 {
+                    var pathsetSchemes = pathSet.SchemeKeys;
+                    var unsupportedSchemes = pathsetSchemes.Except(permissionSchemes);
+                    if (unsupportedSchemes.Any() && validate)
+                    {
+                        errors.Add(new PermissionsError { ErrorCode = PermissionsErrorCode.InvalidPathsetScheme, Message = $"Pathset contains schemes that the permission does not support - {string.Join(',', unsupportedSchemes)}", Path = permission.Key });
+                    }
                     foreach (var path in pathSet.Paths)
                     {
                         var pathKey = this.LenientMatch ? CleanRequestUrl(path.Key) : path.Key;
@@ -237,5 +244,6 @@ namespace Kibali
     {
         DuplicateLeastPrivilegeScopes,
         InvalidLeastPrivilegeScheme,
+        InvalidPathsetScheme
     }
 }

--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.15.0</Version>
+    <Version>0.16.0</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -89,8 +89,8 @@ namespace Kibali
                             Message = string.Format(StringConstants.DuplicateLeastPrivilegeSchemeErrorMessage, string.Join(", ", schemePrivs.Value), scheme, method),
                         });
                     }
+                    }
                 }
-            }
             
             return mismatchedSchemes.Union(duplicateErrors);
         }

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -89,8 +89,8 @@ namespace Kibali
                             Message = string.Format(StringConstants.DuplicateLeastPrivilegeSchemeErrorMessage, string.Join(", ", schemePrivs.Value), scheme, method),
                         });
                     }
-                    }
                 }
+            }
             
             return mismatchedSchemes.Union(duplicateErrors);
         }

--- a/src/kibaliTool/KibaliTool.csproj
+++ b/src/kibaliTool/KibaliTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kibali</ToolCommandName>
-    <Version>0.15.0</Version>
+    <Version>0.16.0</Version>
     <PackageId>Microsoft.Graph.KibaliTool</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/test/kibaliTests/InvalidPermissions/User.json
+++ b/test/kibaliTests/InvalidPermissions/User.json
@@ -362,7 +362,6 @@
                         "GET"
                     ],
                     "schemeKeys": [
-                        "Application",
                         "DelegatedWork"
                     ],
                     "paths": {
@@ -556,8 +555,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/notes/{id}": "",
@@ -649,8 +647,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile": "",
@@ -738,8 +735,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/names": "",
@@ -885,14 +881,12 @@
                         "PATCH"
                     ],
                     "schemeKeys": [
-                        "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/profile/notes/{id}": "least=Application",
+                        "/me/profile/notes/{id}": "",
                         "/me/responsibilities/{id}": "",
-                        "/users/{id}/profile/notes/{id}": "least=Application",
+                        "/users/{id}/profile/notes/{id}": "",
                         "/users/{id}/responsibilities/{id}": ""
                     }
                 },
@@ -901,7 +895,6 @@
                         "GET"
                     ],
                     "schemeKeys": [
-                        "Application",
                         "DelegatedWork",
                         "DelegatedPersonal"
                     ],

--- a/test/kibaliTests/ValidPermissions/User.json
+++ b/test/kibaliTests/ValidPermissions/User.json
@@ -362,7 +362,6 @@
                         "GET"
                     ],
                     "schemeKeys": [
-                        "Application",
                         "DelegatedWork"
                     ],
                     "paths": {
@@ -556,8 +555,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/notes/{id}": "",
@@ -649,8 +647,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile": "",
@@ -738,8 +735,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/names": "",
@@ -885,14 +881,12 @@
                         "PATCH"
                     ],
                     "schemeKeys": [
-                        "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/profile/notes/{id}": "least=Application",
+                        "/me/profile/notes/{id}": "",
                         "/me/responsibilities/{id}": "",
-                        "/users/{id}/profile/notes/{id}": "least=Application",
+                        "/users/{id}/profile/notes/{id}": "",
                         "/users/{id}/responsibilities/{id}": ""
                     }
                 },
@@ -901,15 +895,13 @@
                         "GET"
                     ],
                     "schemeKeys": [
-                        "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/profile": "least=Application",
-                        "/me/profile/account": "least=Application",
+                        "/me/profile": "",
+                        "/me/profile/account": "",
                         "/me/profile/account/{id}": "",
-                        "/me/profile/addresses": "least=Application",
+                        "/me/profile/addresses": "",
                         "/me/profile/addresses/{id}": "",
                         "/me/profile/anniversaries": "",
                         "/me/profile/anniversaries/{id}": "",
@@ -924,7 +916,7 @@
                         "/me/profile/interests": "",
                         "/me/profile/interests/{id}": "",
                         "/me/profile/languages": "",
-                        "/me/profile/languages/{id}": "least=Application",
+                        "/me/profile/languages/{id}": "",
                         "/me/profile/names/{id}": "",
                         "/me/profile/notes": "",
                         "/me/profile/patents": "",
@@ -937,17 +929,17 @@
                         "/me/profile/projects/{id}": "",
                         "/me/profile/publications": "",
                         "/me/profile/publications/{id}": "",
-                        "/me/profile/skills": "least=Application",
+                        "/me/profile/skills": "",
                         "/me/profile/skills/{id}": "",
-                        "/me/profile/webaccounts": "least=Application",
-                        "/me/profile/webaccounts/{id}": "least=Application",
-                        "/me/profile/websites": "least=Application",
+                        "/me/profile/webaccounts": "",
+                        "/me/profile/webaccounts/{id}": "",
+                        "/me/profile/websites": "",
                         "/me/profile/websites/{id}": "",
                         "/me/responsibilities": "",
-                        "/users/{id}/profile": "least=Application",
-                        "/users/{id}/profile/account": "least=Application",
+                        "/users/{id}/profile": "",
+                        "/users/{id}/profile/account": "",
                         "/users/{id}/profile/account/{id}": "",
-                        "/users/{id}/profile/addresses": "least=Application",
+                        "/users/{id}/profile/addresses": "",
                         "/users/{id}/profile/addresses/{id}": "",
                         "/users/{id}/profile/anniversaries": "",
                         "/users/{id}/profile/anniversaries/{id}": "",
@@ -962,7 +954,7 @@
                         "/users/{id}/profile/interests": "",
                         "/users/{id}/profile/interests/{id}": "",
                         "/users/{id}/profile/languages": "",
-                        "/users/{id}/profile/languages/{id}": "least=Application",
+                        "/users/{id}/profile/languages/{id}": "",
                         "/users/{id}/profile/names/{id}": "",
                         "/users/{id}/profile/notes": "",
                         "/users/{id}/profile/patents": "",
@@ -975,11 +967,11 @@
                         "/users/{id}/profile/projects/{id}": "",
                         "/users/{id}/profile/publications": "",
                         "/users/{id}/profile/publications/{id}": "",
-                        "/users/{id}/profile/skills": "least=Application",
+                        "/users/{id}/profile/skills": "",
                         "/users/{id}/profile/skills/{id}": "",
-                        "/users/{id}/profile/webaccounts": "least=Application",
-                        "/users/{id}/profile/webaccounts/{id}": "least=Application",
-                        "/users/{id}/profile/websites": "least=Application",
+                        "/users/{id}/profile/webaccounts": "",
+                        "/users/{id}/profile/webaccounts/{id}": "",
+                        "/users/{id}/profile/websites": "",
                         "/users/{id}/profile/websites/{id}": "",
                         "/users/{id}/responsibilities": ""
                     }
@@ -990,13 +982,11 @@
                         "POST"
                     ],
                     "schemeKeys": [
-                        "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/profile/names": "least=Application",
-                        "/users/{id}/profile/names": "least=Application"
+                        "/me/profile/names": "",
+                        "/users/{id}/profile/names": ""
                     }
                 },
                 {
@@ -1004,12 +994,11 @@
                         "POST"
                     ],
                     "schemeKeys": [
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/translateexchangeids": "least=DelegatedWork,DelegatedPersonal",
-                        "/users/{id}/translateexchangeids": "least=DelegatedWork,DelegatedPersonal"
+                        "/me/translateexchangeids": "least=DelegatedWork",
+                        "/users/{id}/translateexchangeids": "least=DelegatedWork"
                     }
                 }
             ]
@@ -1105,11 +1094,10 @@
                         "PUT"
                     ],
                     "schemeKeys": [
-                        "Application",
                         "DelegatedWork"
                     ],
                     "paths": {
-                        "/settings/regionalandlanguagesettings": "least=Application,DelegatedWork"
+                        "/settings/regionalandlanguagesettings": "least=DelegatedWork"
                     }
                 },
                 {
@@ -1481,8 +1469,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/notes/{id}": "",
@@ -1534,8 +1521,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile": "",
@@ -1549,8 +1535,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/account": "",

--- a/test/kibaliTests/ValidUser.json
+++ b/test/kibaliTests/ValidUser.json
@@ -365,7 +365,6 @@
                         "GET"
                     ],
                     "schemeKeys": [
-                        "Application",
                         "DelegatedWork"
                     ],
                     "paths": {
@@ -559,8 +558,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/notes/{id}": "",
@@ -652,8 +650,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile": "",
@@ -741,8 +738,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/names": "",
@@ -888,14 +884,12 @@
                         "PATCH"
                     ],
                     "schemeKeys": [
-                        "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/profile/notes/{id}": "least=Application",
+                        "/me/profile/notes/{id}": "",
                         "/me/responsibilities/{id}": "",
-                        "/users/{id}/profile/notes/{id}": "least=Application",
+                        "/users/{id}/profile/notes/{id}": "",
                         "/users/{id}/responsibilities/{id}": ""
                     }
                 },
@@ -904,15 +898,13 @@
                         "GET"
                     ],
                     "schemeKeys": [
-                        "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/profile": "least=Application",
-                        "/me/profile/account": "least=Application",
+                        "/me/profile": "",
+                        "/me/profile/account": "",
                         "/me/profile/account/{id}": "",
-                        "/me/profile/addresses": "least=Application",
+                        "/me/profile/addresses": "",
                         "/me/profile/addresses/{id}": "",
                         "/me/profile/anniversaries": "",
                         "/me/profile/anniversaries/{id}": "",
@@ -927,7 +919,7 @@
                         "/me/profile/interests": "",
                         "/me/profile/interests/{id}": "",
                         "/me/profile/languages": "",
-                        "/me/profile/languages/{id}": "least=Application",
+                        "/me/profile/languages/{id}": "",
                         "/me/profile/names/{id}": "",
                         "/me/profile/notes": "",
                         "/me/profile/patents": "",
@@ -940,17 +932,17 @@
                         "/me/profile/projects/{id}": "",
                         "/me/profile/publications": "",
                         "/me/profile/publications/{id}": "",
-                        "/me/profile/skills": "least=Application",
+                        "/me/profile/skills": "",
                         "/me/profile/skills/{id}": "",
-                        "/me/profile/webaccounts": "least=Application",
-                        "/me/profile/webaccounts/{id}": "least=Application",
-                        "/me/profile/websites": "least=Application",
+                        "/me/profile/webaccounts": "",
+                        "/me/profile/webaccounts/{id}": "",
+                        "/me/profile/websites": "",
                         "/me/profile/websites/{id}": "",
                         "/me/responsibilities": "",
-                        "/users/{id}/profile": "least=Application",
-                        "/users/{id}/profile/account": "least=Application",
+                        "/users/{id}/profile": "",
+                        "/users/{id}/profile/account": "",
                         "/users/{id}/profile/account/{id}": "",
-                        "/users/{id}/profile/addresses": "least=Application",
+                        "/users/{id}/profile/addresses": "",
                         "/users/{id}/profile/addresses/{id}": "",
                         "/users/{id}/profile/anniversaries": "",
                         "/users/{id}/profile/anniversaries/{id}": "",
@@ -965,7 +957,7 @@
                         "/users/{id}/profile/interests": "",
                         "/users/{id}/profile/interests/{id}": "",
                         "/users/{id}/profile/languages": "",
-                        "/users/{id}/profile/languages/{id}": "least=Application",
+                        "/users/{id}/profile/languages/{id}": "",
                         "/users/{id}/profile/names/{id}": "",
                         "/users/{id}/profile/notes": "",
                         "/users/{id}/profile/patents": "",
@@ -978,11 +970,11 @@
                         "/users/{id}/profile/projects/{id}": "",
                         "/users/{id}/profile/publications": "",
                         "/users/{id}/profile/publications/{id}": "",
-                        "/users/{id}/profile/skills": "least=Application",
+                        "/users/{id}/profile/skills": "",
                         "/users/{id}/profile/skills/{id}": "",
-                        "/users/{id}/profile/webaccounts": "least=Application",
-                        "/users/{id}/profile/webaccounts/{id}": "least=Application",
-                        "/users/{id}/profile/websites": "least=Application",
+                        "/users/{id}/profile/webaccounts": "",
+                        "/users/{id}/profile/webaccounts/{id}": "",
+                        "/users/{id}/profile/websites": "",
                         "/users/{id}/profile/websites/{id}": "",
                         "/users/{id}/responsibilities": ""
                     }
@@ -993,13 +985,11 @@
                         "POST"
                     ],
                     "schemeKeys": [
-                        "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/profile/names": "least=Application",
-                        "/users/{id}/profile/names": "least=Application"
+                        "/me/profile/names": "",
+                        "/users/{id}/profile/names": ""
                     }
                 },
                 {
@@ -1007,12 +997,11 @@
                         "POST"
                     ],
                     "schemeKeys": [
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
-                        "/me/translateexchangeids": "least=DelegatedWork,DelegatedPersonal",
-                        "/users/{id}/translateexchangeids": "least=DelegatedWork,DelegatedPersonal"
+                        "/me/translateexchangeids": "least=DelegatedWork",
+                        "/users/{id}/translateexchangeids": "least=DelegatedWork"
                     }
                 }
             ]
@@ -1108,11 +1097,10 @@
                         "PUT"
                     ],
                     "schemeKeys": [
-                        "Application",
                         "DelegatedWork"
                     ],
                     "paths": {
-                        "/settings/regionalandlanguagesettings": "least=Application,DelegatedWork"
+                        "/settings/regionalandlanguagesettings": "least=DelegatedWork"
                     }
                 },
                 {
@@ -1484,8 +1472,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/notes/{id}": "",
@@ -1537,8 +1524,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile": "",
@@ -1552,8 +1538,7 @@
                     ],
                     "schemeKeys": [
                         "Application",
-                        "DelegatedWork",
-                        "DelegatedPersonal"
+                        "DelegatedWork"
                     ],
                     "paths": {
                         "/me/profile/account": "",

--- a/test/kibaliTests/ValidationTests.cs
+++ b/test/kibaliTests/ValidationTests.cs
@@ -74,5 +74,35 @@ public class ValidationTests
         Assert.Contains("/me", errors.Select(e => e.Path));
         Assert.Contains("/users/{id}/licensedetails", errors.Select(e => e.Path));
     }
-   
+
+    [Fact]
+    public void ValdiateInvalidScheme()
+    {
+        // Arrange
+        var doc = new PermissionsDocument();
+        var fooRead = new Permission
+        {
+            Schemes = new SortedDictionary<string, Scheme>()
+            {
+                { "DelegatedWork", new Scheme() }
+            },
+            PathSets = {
+            new PathSet() {
+                SchemeKeys = { "Application" },
+                Methods = { "GET" },
+                Paths = { { "/foo",  "least=Application" } }
+            }
+            }
+        };
+        doc.Permissions.Add("Foo.Read", fooRead);
+        // Act
+        var authZChecker = new AuthZChecker();
+        var errors = authZChecker.Validate(doc);
+
+        // Assert
+        Assert.True(errors.Any());
+        Assert.Contains(PermissionsErrorCode.InvalidPathsetScheme, errors.Select(e => e.ErrorCode));
+
+    }
+
 }

--- a/test/kibaliTests/ValidationTests.cs
+++ b/test/kibaliTests/ValidationTests.cs
@@ -37,7 +37,6 @@ public class ValidationTests
 
         // Assert
         Assert.True(errors.Any());
-        Assert.True(errors.Count == 2);
         Assert.Contains(PermissionsErrorCode.DuplicateLeastPrivilegeScopes, errors.Select(e => e.ErrorCode));
         Assert.Contains(PermissionsErrorCode.InvalidLeastPrivilegeScheme, errors.Select(e => e.ErrorCode));
         Assert.Contains("/me", errors.Select(e => e.Path));
@@ -68,7 +67,6 @@ public class ValidationTests
 
         // Assert
         Assert.True(errors.Any());
-        Assert.True(errors.Count == 3);
         Assert.Contains(PermissionsErrorCode.DuplicateLeastPrivilegeScopes, errors.Select(e => e.ErrorCode));
         Assert.Contains(PermissionsErrorCode.InvalidLeastPrivilegeScheme, errors.Select(e => e.ErrorCode));
         Assert.Contains("/me", errors.Select(e => e.Path));


### PR DESCRIPTION
We need to ensure that the scheme keys provided in the pathsets are a subset of the schemes provided by the permission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/65)