### PR TITLE
Update documentation generation to return an empty table if the least privilege is absent even with other permissions present

### DIFF
--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.17.0</Version>
+    <Version>0.18.0</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -44,7 +44,7 @@ public class PermissionsStubGenerator
     }
 
     private string UnsupportedPermissionsStub(){
-        var permissionsStub = "Not supported.";
+        var permissionsStub = StringConstants.PermissionNotSupported;
         var markdownBuilder = new MarkDownBuilder();
         markdownBuilder.StartTable("Permission type", "Least privileged permissions", "Higher privileged permissions");
 

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -176,20 +176,24 @@ namespace Kibali
         public string GeneratePermissionsTable(string method, Dictionary<string, List<AcceptableClaim>> methodClaims)
         {
             var leastPrivilege = this.FetchLeastPrivilege(method);
+            var allRowsAreValid = true;
             var markdownBuilder = new MarkDownBuilder();
             markdownBuilder.StartTable("Permission type", "Least privileged permissions", "Higher privileged permissions");
  
             (var least, var higher) = GetTableScopes("DelegatedWork", methodClaims, leastPrivilege[method]);
             markdownBuilder.AddTableRow("Delegated (work or school account)", least, higher);
+            allRowsAreValid &= TableRowIsValid(least, higher);
 
             (least, higher) = GetTableScopes("DelegatedPersonal", methodClaims, leastPrivilege[method]);
             markdownBuilder.AddTableRow("Delegated (personal Microsoft account)", least, higher);
+            allRowsAreValid &= TableRowIsValid(least, higher);
 
             (least, higher) = GetTableScopes("Application", methodClaims, leastPrivilege[method]);
             markdownBuilder.AddTableRow("Application", least, higher);
-            
+            allRowsAreValid &= TableRowIsValid(least, higher);
+
             markdownBuilder.EndTable();
-            return markdownBuilder.ToString();
+            return allRowsAreValid ? markdownBuilder.ToString() : string.Empty;
         }
 
         public Dictionary<string, Dictionary<string, HashSet<string>>> FetchLeastPrivilege(string method = null, string scheme = null)
@@ -267,9 +271,9 @@ namespace Kibali
         {
             var permissionsStub = new List<string>();
 
-            var delegatedWorkScopes = methodClaims.TryGetValue(scheme, out List<AcceptableClaim> claims) ? claims.OrderByDescending(c => c.Least).Select(c => c.Permission) : permissionsStub;
+            var schemeScopes = methodClaims.TryGetValue(scheme, out List<AcceptableClaim> claims) ? claims.OrderByDescending(c => c.Least).Select(c => c.Permission) : permissionsStub;
             leastPrivilege.TryGetValue(scheme, out HashSet<string> scopes);
-            (var least, var higher) = ExtractScopes(delegatedWorkScopes, scopes);
+            (var least, var higher) = ExtractScopes(schemeScopes, scopes);
             return (least, higher);
         }
 
@@ -333,11 +337,20 @@ namespace Kibali
         
         private (string least, string higher) ExtractScopes(IEnumerable<string> orderedScopes, HashSet<string> leastPrivilege)
         {
-            var least = leastPrivilege != null && leastPrivilege.Any() ? leastPrivilege.First() : "Not supported.";
+            var least = leastPrivilege != null && leastPrivilege.Any() ? leastPrivilege.First() : StringConstants.PermissionNotSupported;
             var filteredScopes = orderedScopes.Where(s => s!= least);
-            var higher = filteredScopes.Any() ? string.Join(", ", filteredScopes) : leastPrivilege != null && leastPrivilege.Any() ? "Not available." : "Not supported.";
+            var higher = filteredScopes.Any() ? string.Join(", ", filteredScopes) : leastPrivilege != null && leastPrivilege.Any() ? StringConstants.PermissionNotAvailable : StringConstants.PermissionNotSupported;
             return (least, higher);
         }
-    }
 
+        private bool TableRowIsValid(string least, string higher)
+        {
+            // Row is invalid if we don't have least privilege permissions but have higher privileged permissions.
+            if (least == StringConstants.PermissionNotSupported && (higher != StringConstants.PermissionNotSupported && higher != StringConstants.PermissionNotAvailable))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
 }

--- a/src/kibali/StringConstants.cs
+++ b/src/kibali/StringConstants.cs
@@ -5,4 +5,8 @@ public class StringConstants
     internal const string UnexpectedLeastPrivilegeSchemeErrorMessage = "Unexpected Least Privilege Scheme '{0}' for scope '{1}'. Expected Schemes: {2}";
 
     internal const string DuplicateLeastPrivilegeSchemeErrorMessage = "Duplicate Least Privilege Scopes {0} for Scheme '{1}' for Method '{2}' ";
+
+    internal const string PermissionNotSupported = "Not supported.";
+
+    internal const string PermissionNotAvailable = "Not available.";
 }

--- a/src/kibaliTool/KibaliTool.csproj
+++ b/src/kibaliTool/KibaliTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kibali</ToolCommandName>
-    <Version>0.17.0</Version>
+    <Version>0.18.0</Version>
     <PackageId>Microsoft.Graph.KibaliTool</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -142,6 +142,16 @@ public class DocumentationTests
         
     }
 
+    [Fact]
+    public void DocumentationTableNotGeneratedInvalidRow()
+    {
+        var permissionsDocument = CreatePermissionsDocument();
+
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/fooNoPrivilege", "GET", true);
+        var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+        var expectedTable = string.Empty;
+        Assert.Equal(expectedTable, table);
+    }
 
     private static PermissionsDocument CreatePermissionsDocument()
     {


### PR DESCRIPTION
We need to avoid generating the docs if the paths have permissions without any of them being marked as the least privileged. This will prevent the docs from being overwritten when the model doesn't have least privilege information.