### PR TITLE
Proposal: Add support for MSA permissions in the provisioning metadata

### DIFF
--- a/specs/permissions-deployment-schema.json
+++ b/specs/permissions-deployment-schema.json
@@ -26,6 +26,9 @@
                             },
                             "isEnabled": {
                                 "type": "boolean"
+                            },
+                            "supportsMSA": {
+                                "type": "boolean"
                             }
                         },
                         "required": [

--- a/specs/permissions-deployments.md
+++ b/specs/permissions-deployments.md
@@ -70,3 +70,6 @@ The "isEnabled" member is a boolean value that indicates if a permission is enab
 
 #### resourceAppId
 The "resourceAppId" member value provides an identifier of the resource server that is used to enforce Conditional Access checks for this permission.
+
+#### supportsMSA
+The "supportsMSA" member is a boolean value that indicates if a permission is deployed in the MSA environment.


### PR DESCRIPTION
We need a way to annotate which permissions support MSA so that the provisioning team is better equipped to provision the information. This is a proposal to add a `supportsMSA` flag to the provisioning info so that permissions can be better provisioned in the correct environments.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/73)