### PR TITLE
Merge permissions for multiple paths into the same table

### DIFF
--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.19.0</Version>
+    <Version>0.20.0</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -122,10 +122,9 @@ public class PermissionsStubGenerator
     {
         var notPresent = new[] { StringConstants.PermissionNotSupported, StringConstants.PermissionNotAvailable };
         var groupedSchemePermissions = new Dictionary<string, (string, string)>();
-        foreach (var schemeEntry in mergedTableScopes)
+        foreach (var (scheme, value) in mergedTableScopes)
         {
-            var scheme = schemeEntry.Key;
-            var least = schemeEntry.Value["least"];
+            var least = value["least"];
             string mergedLeast;
             if (least.Count == 1)
             {
@@ -153,7 +152,7 @@ public class PermissionsStubGenerator
                 }
             }
 
-            var higher = schemeEntry.Value["higher"];
+            var higher = value["higher"];
             string mergedHigher;
             if (higher.Count == 1)
             {

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -35,10 +35,7 @@ public class PermissionsStubGenerator
         {
             return GenerateMultiplePathsTable();
         }
-        else
-        {
-            return GenerateSinglePathTable();
-        }
+        return GenerateSinglePathTable();
         
     }
 

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Kibali;
@@ -137,9 +138,7 @@ public class PermissionsStubGenerator
                 {
                     if (filtered.Count() > 1)
                     {
-                        mergedLeast = filtered.OrderBy(m => m).First();
-                        // TODO: Track these cases
-                        ////throw new ArgumentException("Unable to merge least privilege permissions.");
+                        throw new ArgumentException($"Differing least privilege permissions {string.Join(",", filtered)} for the scheme {scheme}.");
                     }
                     else
                     {

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -167,14 +167,7 @@ public class PermissionsStubGenerator
                 var filtered = higher.Concat(least).Except(toSkip);
                 if (filtered.Any())
                 {
-                    if (filtered.Count() > 1)
-                    {
-                        mergedHigher = string.Join(", ", filtered);
-                    }
-                    else
-                    {
-                        mergedHigher = filtered.First();
-                    }
+                    mergedHigher = string.Join(", ", filtered);
                 }
                 else
                 {

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -161,7 +161,7 @@ public class PermissionsStubGenerator
             }
             else
             {
-                least.Remove(mergedLeast); // Remove least privileged permission and add the rest to the least
+                least.Remove(mergedLeast); // Remove least privileged permission and add the rest to the higher privileged permissions.
                 var toSkip = notPresent.Append(mergedLeast);
                 var filtered = higher.Concat(least).Except(toSkip);
                 if (filtered.Any())

--- a/src/kibali/PermissionsStubGenerator.cs
+++ b/src/kibali/PermissionsStubGenerator.cs
@@ -106,7 +106,7 @@ public class PermissionsStubGenerator
         {
             var least = scheme.Value.Item1;
             var higher = scheme.Value.Item2.Split(',').Select(k => k.Trim());
-            if (mergedTableScopes.TryGetValue(scheme.Key, out Dictionary<string, SortedSet<string>> mergedScopes))
+            if (mergedTableScopes.TryGetValue(scheme.Key, out var mergedScopes))
             {
                 mergedScopes["least"].Add(least);
                 mergedScopes["higher"].UnionWith(higher);

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -175,25 +175,21 @@ namespace Kibali
 
         public string GeneratePermissionsTable(string method, Dictionary<string, List<AcceptableClaim>> methodClaims)
         {
+            var scopesByScheme = FetchTableScopesByScheme(method, methodClaims);
+
+            return TableGenerator.GeneratePermissionsTable(scopesByScheme);
+        }
+
+        public Dictionary<string, (string, string)> FetchTableScopesByScheme(string method, Dictionary<string, List<AcceptableClaim>> methodClaims)
+        {
+            var scopesByScheme = new Dictionary<string, (string, string)>();
             var leastPrivilege = this.FetchLeastPrivilege(method);
-            var allRowsAreValid = true;
-            var markdownBuilder = new MarkDownBuilder();
-            markdownBuilder.StartTable("Permission type", "Least privileged permissions", "Higher privileged permissions");
- 
-            (var least, var higher) = GetTableScopes("DelegatedWork", methodClaims, leastPrivilege[method]);
-            markdownBuilder.AddTableRow("Delegated (work or school account)", least, higher);
-            allRowsAreValid &= TableRowIsValid(least, higher);
-
-            (least, higher) = GetTableScopes("DelegatedPersonal", methodClaims, leastPrivilege[method]);
-            markdownBuilder.AddTableRow("Delegated (personal Microsoft account)", least, higher);
-            allRowsAreValid &= TableRowIsValid(least, higher);
-
-            (least, higher) = GetTableScopes("Application", methodClaims, leastPrivilege[method]);
-            markdownBuilder.AddTableRow("Application", least, higher);
-            allRowsAreValid &= TableRowIsValid(least, higher);
-
-            markdownBuilder.EndTable();
-            return allRowsAreValid ? markdownBuilder.ToString() : string.Empty;
+            var schemeKeys = new[] { "DelegatedWork", "Application", "DelegatedPersonal" };
+            foreach (var scheme in schemeKeys)
+            {
+                scopesByScheme[scheme] = GetTableScopes(scheme, methodClaims, leastPrivilege[method]);
+            }
+            return scopesByScheme;
         }
 
         public Dictionary<string, Dictionary<string, HashSet<string>>> FetchLeastPrivilege(string method = null, string scheme = null)
@@ -341,16 +337,6 @@ namespace Kibali
             var filteredScopes = orderedScopes.Where(s => s!= least);
             var higher = filteredScopes.Any() ? string.Join(", ", filteredScopes) : leastPrivilege != null && leastPrivilege.Any() ? StringConstants.PermissionNotAvailable : StringConstants.PermissionNotSupported;
             return (least, higher);
-        }
-
-        private bool TableRowIsValid(string least, string higher)
-        {
-            // Row is invalid if we don't have least privilege permissions but have higher privileged permissions.
-            if (least.Equals(StringConstants.PermissionNotSupported,StringComparison.OrdinalIgnoreCase) && (!higher.Equals(StringConstants.PermissionNotSupported, StringComparison.OrdinalIgnoreCase) && !higher.Equals(StringConstants.PermissionNotAvailable, StringComparison.OrdinalIgnoreCase)))
-            {
-                return false;
-            }
-            return true;
         }
     }
 }

--- a/src/kibali/TableGenerator.cs
+++ b/src/kibali/TableGenerator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kibali;
+
+public static class TableGenerator
+{
+    public static string GeneratePermissionsTable(Dictionary<string, (string, string)> scopesByScheme)
+    {
+        var allRowsAreValid = true;
+        var markdownBuilder = new MarkDownBuilder();
+        markdownBuilder.StartTable("Permission type", "Least privileged permissions", "Higher privileged permissions");
+
+        (var least, var higher) = scopesByScheme["DelegatedWork"];
+        markdownBuilder.AddTableRow("Delegated (work or school account)", least, higher);
+        allRowsAreValid &= TableRowIsValid(least, higher);
+
+        (least, higher) = scopesByScheme["DelegatedPersonal"];
+        markdownBuilder.AddTableRow("Delegated (personal Microsoft account)", least, higher);
+        allRowsAreValid &= TableRowIsValid(least, higher);
+
+        (least, higher) = scopesByScheme["Application"];
+        markdownBuilder.AddTableRow("Application", least, higher);
+        allRowsAreValid &= TableRowIsValid(least, higher);
+
+        markdownBuilder.EndTable();
+        return allRowsAreValid ? markdownBuilder.ToString() : string.Empty;
+    }
+
+    private static bool TableRowIsValid(string least, string higher)
+    {
+        // Row is invalid if we don't have least privilege permissions but have higher privileged permissions.
+        if (least.Equals(StringConstants.PermissionNotSupported, StringComparison.OrdinalIgnoreCase) && (!higher.Equals(StringConstants.PermissionNotSupported, StringComparison.OrdinalIgnoreCase) && !higher.Equals(StringConstants.PermissionNotAvailable, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/kibaliTool/DocumentCommand.cs
+++ b/src/kibaliTool/DocumentCommand.cs
@@ -38,7 +38,10 @@ internal class DocumentCommand
             throw new ArgumentException("Please provide a method");
         }
 
-        var generator = new PermissionsStubGenerator(doc, documentCommandParameters.Url, documentCommandParameters.Method, lenientMatch: true) { MergeMultiplePaths = documentCommandParameters.CombineMultiple };
+        var generator = new PermissionsStubGenerator(doc, documentCommandParameters.Url, documentCommandParameters.Method, lenientMatch: true) 
+        { 
+            MergeMultiplePaths = documentCommandParameters.CombineMultiple 
+        };
         var table = generator.GenerateTable();
         Console.WriteLine(table);
 

--- a/src/kibaliTool/DocumentCommand.cs
+++ b/src/kibaliTool/DocumentCommand.cs
@@ -11,6 +11,7 @@ internal class DocumentCommandParameters
     public string SourcePermissionsFolder;
     public string Url;
     public string Method;
+    public bool CombineMultiple;
 }
 
 internal class DocumentCommand
@@ -37,7 +38,7 @@ internal class DocumentCommand
             throw new ArgumentException("Please provide a method");
         }
 
-        var generator = new PermissionsStubGenerator(doc, documentCommandParameters.Url, documentCommandParameters.Method, lenientMatch: true);
+        var generator = new PermissionsStubGenerator(doc, documentCommandParameters.Url, documentCommandParameters.Method, lenientMatch: true) { MergeMultiplePaths = documentCommandParameters.CombineMultiple };
         var table = generator.GenerateTable();
         Console.WriteLine(table);
 

--- a/src/kibaliTool/KibaliTool.csproj
+++ b/src/kibaliTool/KibaliTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kibali</ToolCommandName>
-    <Version>0.19.0</Version>
+    <Version>0.20.0</Version>
     <PackageId>Microsoft.Graph.KibaliTool</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibaliTool/Program.cs
+++ b/src/kibaliTool/Program.cs
@@ -50,6 +50,7 @@ namespace KibaliTool
                 DocumentCommandBinder.PermissionFolderOption,
                 DocumentCommandBinder.UrlOption,
                 DocumentCommandBinder.MethodOption,
+                DocumentCommandBinder.CombineMultipleOption,
             };
 
             documentCommand.SetHandler(DocumentCommand.Execute, new DocumentCommandBinder());
@@ -150,6 +151,7 @@ namespace KibaliTool
         public static readonly Option<string> PermissionFolderOption = new(new[] { "--sourcePermissionsFolder", "--fo" }, "Permission Folder");
         public static readonly Option<string> UrlOption = new(new[] { "--url", "-u" }, "Test Url");
         public static readonly Option<string> MethodOption = new(new[] { "--method", "-m" }, "Method");
+        public static readonly Option<bool> CombineMultipleOption = new(new[] { "--combine", "-c" }, "Combine Multiple Paths");
         protected override DocumentCommandParameters GetBoundValue(BindingContext bindingContext)
         {
             return new DocumentCommandParameters()
@@ -158,6 +160,7 @@ namespace KibaliTool
                 SourcePermissionsFolder = bindingContext.ParseResult.GetValueForOption(PermissionFolderOption),
                 Url = bindingContext.ParseResult.GetValueForOption(UrlOption),
                 Method = bindingContext.ParseResult.GetValueForOption(MethodOption),
+                CombineMultiple = bindingContext.ParseResult.GetValueForOption(CombineMultipleOption)
             };
         }
     }

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -193,22 +193,14 @@ public class DocumentationTests
     }
 
     [Fact]
-    public void DocumentationTableGeneratedMultiplePathsMultipleLPP()
+    public void DocumentationTableThrowsExceptionMultiplePathsMultipleLPP()
     {
         var permissionsDocument = CreatePermissionsDocument();
 
         var generator = new PermissionsStubGenerator(permissionsDocument, "/fooOther;/fooBar", "GET", true, true) { MergeMultiplePaths = true };
-        var table = generator.GenerateTable();
-        var actualTable = table.Replace("\r\n", string.Empty).Replace("\n", string.Empty);
-
-        var expectedTable = @"
-|Permission type|Least privileged permissions|Higher privileged permissions|
-|:---|:---|:---|
-|Delegated (work or school account)|Bar.ReadWrite|Foo.ReadWrite|
-|Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Bar.ReadWrite|Not available.|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
-
-        Assert.Equal(expectedTable, actualTable);
+        var generateTable = () => generator.GenerateTable();
+        var exception = Assert.Throws<ArgumentException>(generateTable);
+        Assert.Equal("Differing least privilege permissions Bar.ReadWrite,Foo.ReadWrite for the scheme Application.", exception.Message);
 
     }
 

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -4,12 +4,14 @@ namespace KibaliTests;
 
 public class DocumentationTests
 {
-    [Fact]
-    public void DocumentationTableGenerated()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableGenerated(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", "GET", true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", "GET", true) { MergeMultiplePaths = mergeMultiplePaths};
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         var expectedTable = @"
@@ -24,12 +26,14 @@ public class DocumentationTests
     }
 
 
-    [Fact]
-    public void DocumentationTableGeneratedLenient()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableGeneratedLenient(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/(value={value})", "GET", true, true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/(value={value})", "GET", true, true) { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         var expectedTable = @"
@@ -43,12 +47,14 @@ public class DocumentationTests
 
     }
 
-    [Fact]
-    public void DocumentationTableNotGeneratedNotLenient()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableNotGeneratedNotLenient(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/(value={value})", "GET", true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/(value={value})", "GET", true) { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         var expectedTable = @"
@@ -62,12 +68,14 @@ public class DocumentationTests
 
     }
 
-    [Fact]
-    public void DocumentationTableNotGeneratedMissingPath()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableNotGeneratedMissingPath(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/bar", "GET", true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/bar", "GET", true) { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
         var expectedTable = @"
 |Permission type|Least privileged permissions|Higher privileged permissions|
@@ -79,12 +87,14 @@ public class DocumentationTests
 
     }
 
-    [Fact]
-    public void DocumentationTableNotGeneratedNoMethod()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableNotGeneratedNoMethod(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", null, true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", null, true) { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
         var expectedTable = @"
 |Permission type|Least privileged permissions|Higher privileged permissions|
@@ -96,12 +106,14 @@ public class DocumentationTests
 
     }
 
-    [Fact]
-    public void DocumentationTableNotGeneratedUnsupportedMethod()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableNotGeneratedUnsupportedMethod(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", "PATCH", true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", "PATCH", true) { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
         var expectedTable = @"
 |Permission type|Least privileged permissions|Higher privileged permissions|
@@ -113,12 +125,14 @@ public class DocumentationTests
 
     }
 
-    [Fact]
-    public void DocumentationTableNotGeneratedNoPrivilege()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableNotGeneratedNoPrivilege(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/fooNoPrivilege", null, true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/fooNoPrivilege", null, true) { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
         var expectedTable = @"
 |Permission type|Least privileged permissions|Higher privileged permissions|
@@ -130,27 +144,92 @@ public class DocumentationTests
 
     }
 
-    [Fact]
-    public void DocumentationTableNotGeneratedNoDefault()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableNotGeneratedNoDefault(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", "PATCH");
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo", "PATCH") { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
         var expectedTable = string.Empty;
         Assert.Equal(expectedTable, table);
         
     }
 
-    [Fact]
-    public void DocumentationTableNotGeneratedInvalidRow()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DocumentationTableNotGeneratedInvalidRow(bool mergeMultiplePaths)
     {
         var permissionsDocument = CreatePermissionsDocument();
 
-        var generator = new PermissionsStubGenerator(permissionsDocument, "/fooNoPrivilege", "GET", true);
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/fooNoPrivilege", "GET", true) { MergeMultiplePaths = mergeMultiplePaths };
         var table = generator.GenerateTable().Replace("\r\n", string.Empty).Replace("\n", string.Empty);
         var expectedTable = string.Empty;
         Assert.Equal(expectedTable, table);
+    }
+
+
+    [Fact]
+    public void DocumentationTableGeneratedMultiplePaths()
+    {
+        var permissionsDocument = CreatePermissionsDocument();
+
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/foo/(value={value});/fooOther", "GET", true, true) { MergeMultiplePaths = true };
+        var table = generator.GenerateTable();
+        var actualTable = table.Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+
+        var expectedTable = @"
+|Permission type|Least privileged permissions|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Foo.Read|Foo.ReadWrite|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Foo.ReadWrite|Not available.|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+
+        Assert.Equal(expectedTable, actualTable);
+
+    }
+
+    [Fact]
+    public void DocumentationTableGeneratedMultiplePathsMultipleLPP()
+    {
+        var permissionsDocument = CreatePermissionsDocument();
+
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/fooOther;/fooBar", "GET", true, true) { MergeMultiplePaths = true };
+        var table = generator.GenerateTable();
+        var actualTable = table.Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+
+        var expectedTable = @"
+|Permission type|Least privileged permissions|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Bar.ReadWrite|Foo.ReadWrite|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Bar.ReadWrite|Not available.|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+
+        Assert.Equal(expectedTable, actualTable);
+
+    }
+
+    [Fact]
+    public void DocumentationTableGeneratedMultiplePathsMultipleHPP()
+    {
+        var permissionsDocument = CreatePermissionsDocument();
+
+        var generator = new PermissionsStubGenerator(permissionsDocument, "/bar;/fooBar", "GET", true, true) { MergeMultiplePaths = true };
+        var table = generator.GenerateTable();
+        var actualTable = table.Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+
+        var expectedTable = @"
+|Permission type|Least privileged permissions|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Bar.ReadWrite|Foo.Read, Foo.ReadWrite|
+|Delegated (personal Microsoft account)|Foo.Read|Not available.|
+|Application|Bar.ReadWrite|Foo.ReadWrite|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+
+        Assert.Equal(expectedTable, actualTable);
+
     }
 
     private static PermissionsDocument CreatePermissionsDocument()
@@ -168,7 +247,19 @@ public class DocumentationTests
                                 "DelegatedWork"
                             },
                             Paths = {
-                                { "/foo",  "least=DelegatedWork" }
+                                { "/foo",  "least=DelegatedWork" },
+                                { "/bar",  "" }
+                            }
+                        },
+                        new PathSet() {
+                            Methods = {
+                                "GET"
+                            },
+                            SchemeKeys = {
+                                "DelegatedPersonal"
+                            },
+                            Paths = {
+                                { "/bar",  "least=DelegatedPersonal" }
                             }
                         }
                     }
@@ -187,13 +278,35 @@ public class DocumentationTests
                             },
                             Paths = {
                                 { "/foo",  "least=Application" },
-                                { "/fooNoPrivilege",  "" }
+                                { "/fooNoPrivilege",  "" },
+                                { "/fooOther",  "least=Application" },
+                                { "/bar",  "" }
+                            }
+                        }
+                    }
+        };
+        var barReadWrite = new Permission
+        {
+            PathSets = {
+                        new PathSet() {
+                            Methods = {
+                                "GET",
+                                "POST"
+                            },
+                            SchemeKeys = {
+                                "Application",
+                                "DelegatedWork"
+                            },
+                            Paths = {
+                                { "/fooBar",  "least=Application,DelegatedWork" },
+                                { "/bar",  "" }
                             }
                         }
                     }
         };
         permissionsDocument.Permissions.Add("Foo.Read", fooRead);
         permissionsDocument.Permissions.Add("Foo.ReadWrite", fooReadWrite);
+        permissionsDocument.Permissions.Add("Bar.ReadWrite", barReadWrite);
         return permissionsDocument;
     }
 }


### PR DESCRIPTION
We have an issue where the permissions are disjointed in the model and not all paths in the page have the same permissions. For example, paths that start with `/me` don't have Application permissions whereas paths with `/users` do. API Doctor currently picks the first path when rendering the permissions table and as a result we end up with tables that are missing some of the entries. In the example provided, the table won't have Application permissions.

See a current example of this bug
https://learn.microsoft.com/en-us/graph/api/virtualappointment-getvirtualappointmentjoinweburl?view=graph-rest-beta&tabs=http#permissions where the Application permissions are missing

The (correct) manual entry was overwritten. See https://github.com/microsoftgraph/microsoft-graph-docs/pull/20996/files

Application permissions are now restored when running it against this branch using both urls (semicolon separated).

![image](https://github.com/microsoftgraph/kibali/assets/1733185/f96413c5-6d85-4503-81ee-7bb32134081f)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/82)