### PR TITLE
Fixes release pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -255,7 +255,7 @@ extends:
               - task: 1ES.PublishNuget@1
                 displayName: 'NuGet push'
                 inputs:
-                  useDotNetTask: true
+                  packageParentPath: '$(Pipeline.Workspace)'
                   packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.Graph.Kibali.*.nupkg'
                   nuGetFeedType: external
                   publishPackageMetadata: true


### PR DESCRIPTION
This PR fixes the release pipeline to 

- Adds mandatory `packageParentPath` parameter 
- drops `useDotNetTask` parameter due to incompatibility with secret managment
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/84)