### PR TITLE
Validate duplicated pathset entries in the permission files and fix permission ordering

### DIFF
--- a/src/kibali/AcceptableClaimComparer.cs
+++ b/src/kibali/AcceptableClaimComparer.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kibali
+{
+    public class AcceptableClaimComparer : IEqualityComparer<AcceptableClaim>
+    {
+        public bool Equals(AcceptableClaim x, AcceptableClaim y)
+        {
+            if (x == null || y == null)
+                return false;
+
+            // Check if Permission is the same
+            if (x.Permission != y.Permission)
+                return false;
+
+            // Check if AlsoRequires is the same
+            if (x.AlsoRequires == null && y.AlsoRequires == null)
+                return true;
+
+            if (x.AlsoRequires == null || y.AlsoRequires == null)
+                return false;
+
+            // Compare the contents of the AlsoRequires arrays
+            return x.AlsoRequires.SequenceEqual(y.AlsoRequires);
+        }
+
+        public int GetHashCode(AcceptableClaim obj)
+        {
+            if (obj == null || obj.Permission == null)
+                return 0;
+
+            int hash = obj.Permission.GetHashCode();
+
+            if (obj.AlsoRequires != null)
+            {
+                foreach (var item in obj.AlsoRequires)
+                {
+                    hash = hash ^ item.GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/kibali/AcceptableClaimComparer.cs
+++ b/src/kibali/AcceptableClaimComparer.cs
@@ -1,8 +1,5 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Kibali
 {
@@ -30,7 +27,7 @@ namespace Kibali
 
         public int GetHashCode(AcceptableClaim obj)
         {
-            if (obj == null || obj.Permission == null)
+            if (obj?.Permission == null)
                 return 0;
 
             int hash = obj.Permission.GetHashCode();
@@ -39,7 +36,7 @@ namespace Kibali
             {
                 foreach (var item in obj.AlsoRequires)
                 {
-                    hash = hash ^ item.GetHashCode();
+                    hash ^= item.GetHashCode();
                 }
             }
 

--- a/src/kibali/AuthZChecker.cs
+++ b/src/kibali/AuthZChecker.cs
@@ -64,16 +64,16 @@ namespace Kibali
             var resource = FindResource(url);
             if (resource == null)
             {
-                return new List<AcceptableClaim>();
+                return new HashSet<AcceptableClaim>(new AcceptableClaimComparer());
             }
             if (!resource.SupportedMethods.TryGetValue(method, out var supportedSchemes))
             {
-                return new List<AcceptableClaim>();
+                return new HashSet<AcceptableClaim>(new AcceptableClaimComparer());
             }
 
             if (!supportedSchemes.TryGetValue(scheme, out var acceptableClaims))
             {
-                return new List<AcceptableClaim>();
+                return new HashSet<AcceptableClaim>(new AcceptableClaimComparer());
             }
 
             return acceptableClaims;
@@ -134,7 +134,7 @@ namespace Kibali
                         }
                         var leastPrivilegedPermissionSchemes = ParseLeastPrivilegeSchemes(path.Value);
                         var alsoRequires = ParseAlsoRequiresPermissions(path.Value);
-                        resource.AddRequiredClaims(permission.Key, pathSet, leastPrivilegedPermissionSchemes, provisioningData, alsoRequires);
+                        errors.UnionWith(resource.AddRequiredClaims(permission.Key, pathSet, leastPrivilegedPermissionSchemes, provisioningData, alsoRequires));
                         if (validate)
                         {
                             foreach (var requiredPermission in alsoRequires)
@@ -305,5 +305,6 @@ namespace Kibali
         InvalidPathsetScheme,
         MissingLeastPrivilegePermission,
         InvalidAlsoRequiresPermission,
+        DuplicatePathsetEntry,
     }
 }

--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.23.0</Version>
+    <Version>0.24.0</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/Kibali.csproj
+++ b/src/kibali/Kibali.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>0.22.0</Version>
+    <Version>0.23.0</Version>
     <PackageId>Microsoft.Graph.Kibali</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -428,7 +428,7 @@ namespace Kibali
             }
             if (higherPrivilegedPairs.Count != 0)
             {
-                higher = string.Join(", ", higherPrivilegedPairs.OrderBy(x => x));
+                higher = string.Join(", ", higherPrivilegedPairs);
             }
             else
             {

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Kibali
 {
@@ -19,25 +20,25 @@ namespace Kibali
         // Permissions(delegated) (Graph Explorer Permissions List)
         // Schemas -> Permissions ( AAD Onboarding)
         public string Url { get; set; }
-        public Dictionary<string, Dictionary<string, List<AcceptableClaim>>> SupportedMethods { get; set; } = new Dictionary<string, Dictionary<string, List<AcceptableClaim>>>();
-
+        public Dictionary<string, Dictionary<string, HashSet<AcceptableClaim>>> SupportedMethods { get; set; } = new();
         public Dictionary<(string, string), HashSet<string>> PermissionMethods {get; set;} = new();
         public ProtectedResource(string url)
         {
             Url = url;
         }
 
-        public void AddRequiredClaims(string permission, PathSet pathSet, string[] leastPrivilegedPermissionSchemes, List<ProvisioningInfo> provisioningData, string[] alsoRequires)
+        public HashSet<PermissionsError> AddRequiredClaims(string permission, PathSet pathSet, string[] leastPrivilegedPermissionSchemes, List<ProvisioningInfo> provisioningData, string[] alsoRequires)
         {
+            var errors = new HashSet<PermissionsError>();
             Dictionary<string, ProvisioningInfo> schemeProvisioning = provisioningData?.ToDictionary(info => info.Scheme, info => info) ?? new();
             foreach (var supportedMethod in pathSet.Methods)
             {
-                var supportedSchemes = new Dictionary<string, List<AcceptableClaim>>();
+                var supportedSchemes = new Dictionary<string, HashSet<AcceptableClaim>>();
                 foreach (var schemeKey in pathSet.SchemeKeys)
                 {
                     if(!supportedSchemes.TryGetValue(schemeKey, out var acceptableClaims))
                     {
-                        acceptableClaims = new List<AcceptableClaim>();
+                        acceptableClaims = new HashSet<AcceptableClaim>(new AcceptableClaimComparer());
                         supportedSchemes.Add(schemeKey, acceptableClaims);
                     }
 
@@ -55,7 +56,15 @@ namespace Kibali
                         claim.SupportedEnvironments = provisioningInfo.Environment?.Split(";").ToList();
                         claim.IsEnabled = provisioningInfo.IsEnabled;
                     }
-                    acceptableClaims.Add(claim);
+                    if (!acceptableClaims.Add(claim))
+                    {
+                        errors.Add(new PermissionsError
+                        {
+                            Path = this.Url,
+                            ErrorCode = PermissionsErrorCode.DuplicatePathsetEntry,
+                            Message = string.Format(StringConstants.DuplicatePathsetEntryErrorMessage, permission, this.Url, schemeKey, supportedMethod),
+                        });
+                    }
                 }
 
                 if (!this.SupportedMethods.TryGetValue(supportedMethod, out var existingSupportedSchemes))
@@ -64,9 +73,10 @@ namespace Kibali
                 }
                 else
                 {
-                    Update(existingSupportedSchemes, supportedSchemes);
+                    errors.UnionWith(Update(existingSupportedSchemes, supportedSchemes, permission, supportedMethod));
                 }
             }
+            return errors;
         }
 
         public IEnumerable<PermissionsError> ValidateLeastPrivilegePermissions()
@@ -113,20 +123,33 @@ namespace Kibali
             return errors;
         }
 
-        private void Update(Dictionary<string, List<AcceptableClaim>> existingSchemes, Dictionary<string, List<AcceptableClaim>> newSchemes)
+        private HashSet<PermissionsError> Update(Dictionary<string, HashSet<AcceptableClaim>> existingSchemes, Dictionary<string, HashSet<AcceptableClaim>> newSchemes, string permission, string supportedMethod)
         {
-            
+            var duplicateErrors = new HashSet<PermissionsError>();
             foreach(var newScheme in newSchemes)
             {
                 if (existingSchemes.TryGetValue(newScheme.Key, out var existingScheme))
                 {
-                    existingScheme.AddRange(newScheme.Value);
+                    foreach (var entry in newScheme.Value)
+                    {
+                        if (!existingScheme.Add(entry))
+                        {
+                            duplicateErrors.Add(new PermissionsError
+                            {
+                                Path = this.Url,
+                                ErrorCode = PermissionsErrorCode.DuplicatePathsetEntry,
+                                Message = string.Format(StringConstants.DuplicatePathsetEntryErrorMessage, permission, this.Url, newScheme.Key, supportedMethod),
+                            });
+                        }
+                    }
                 } 
                 else
                 {
                     existingSchemes[newScheme.Key] = newScheme.Value;
                 }
             }
+
+            return duplicateErrors;
         }
 
         public void Write(Utf8JsonWriter writer)
@@ -140,7 +163,7 @@ namespace Kibali
             writer.WriteEndObject();
         }
 
-        private void WriteSupportedMethod(Utf8JsonWriter writer, Dictionary<string, Dictionary<string, List<AcceptableClaim>>> supportedMethods)
+        private void WriteSupportedMethod(Utf8JsonWriter writer, Dictionary<string, Dictionary<string, HashSet<AcceptableClaim>>> supportedMethods)
         {
             writer.WriteStartObject();
             foreach (var item in supportedMethods)
@@ -151,7 +174,7 @@ namespace Kibali
             writer.WriteEndObject();
         }
 
-        public void WriteSupportedSchemes(Utf8JsonWriter writer, Dictionary<string, List<AcceptableClaim>> methodClaims)
+        public void WriteSupportedSchemes(Utf8JsonWriter writer, Dictionary<string, HashSet<AcceptableClaim>> methodClaims)
         {
             writer.WriteStartObject();
             foreach (var item in methodClaims)
@@ -162,7 +185,7 @@ namespace Kibali
             writer.WriteEndObject();
         }
 
-        public void WriteAcceptableClaims(Utf8JsonWriter writer, List<AcceptableClaim> schemes)
+        public void WriteAcceptableClaims(Utf8JsonWriter writer, HashSet<AcceptableClaim> schemes)
         {
             writer.WriteStartArray();
             foreach (var item in schemes.OrderByDescending(c => c.Least))
@@ -172,14 +195,14 @@ namespace Kibali
             writer.WriteEndArray();
         }
 
-        public string GeneratePermissionsTable(string method, Dictionary<string, List<AcceptableClaim>> methodClaims)
+        public string GeneratePermissionsTable(string method, Dictionary<string, HashSet<AcceptableClaim>> methodClaims)
         {
             var scopesByScheme = FetchTableScopesByScheme(method, methodClaims);
 
             return TableGenerator.GeneratePermissionsTable(scopesByScheme);
         }
 
-        public Dictionary<string, (string, string)> FetchTableScopesByScheme(string method, Dictionary<string, List<AcceptableClaim>> methodClaims)
+        public Dictionary<string, (string, string)> FetchTableScopesByScheme(string method, Dictionary<string, HashSet<AcceptableClaim>> methodClaims)
         {
             var scopesByScheme = new Dictionary<string, (string, string)>();
             var leastPrivilege = this.FetchLeastPrivilege(method);
@@ -246,7 +269,7 @@ namespace Kibali
             }
         }
 
-        private void GetLeastPrivilegeForAllSchemesMappedToMethod(string method, Dictionary<string, Dictionary<string, HashSet<string>>> leastPrivilege, Dictionary<string, List<AcceptableClaim>> supportedSchemes)
+        private void GetLeastPrivilegeForAllSchemesMappedToMethod(string method, Dictionary<string, Dictionary<string, HashSet<string>>> leastPrivilege, Dictionary<string, HashSet<AcceptableClaim>> supportedSchemes)
         {
             foreach (var supportedScheme in supportedSchemes.OrderBy(s => Enum.Parse(typeof(SchemeType), s.Key)))
             {
@@ -282,11 +305,11 @@ namespace Kibali
             return output;
         }
  
-        private (string least, string higher) GetTableScopes(string scheme, Dictionary<string, List<AcceptableClaim>> methodClaims, Dictionary<string, HashSet<string>> leastPrivilegeScopesPerScheme)
+        private (string least, string higher) GetTableScopes(string scheme, Dictionary<string, HashSet<AcceptableClaim>> methodClaims, Dictionary<string, HashSet<string>> leastPrivilegeScopesPerScheme)
         {
             IEnumerable<AcceptableClaim> orderedClaims = Enumerable.Empty<AcceptableClaim>();
             var schemeScopes = new List<string>();
-            if (methodClaims.TryGetValue(scheme, out List<AcceptableClaim> claims))
+            if (methodClaims.TryGetValue(scheme, out HashSet<AcceptableClaim> claims))
             {
                 orderedClaims = claims.OrderByDescending(c => c.Least);
                 schemeScopes = orderedClaims.Select(c => c.Permission).ToList();
@@ -449,7 +472,20 @@ namespace Kibali
             
             if (permissionPairs.Any())
             {
-                return permissionPairs.Select(p => $"{p.Item1} and {p.Item2}").ToHashSet();
+                var leastPrivilegePairs = new HashSet<string>();
+                foreach (var pair in permissionPairs)
+                {
+                    if (pair.Item1 != string.Empty && pair.Item2 != string.Empty)
+                    {
+                        leastPrivilegePairs.Add($"{pair.Item1} and {pair.Item2}");
+                    }
+                    else
+                    {
+                        var toAdd = pair.Item1 == string.Empty ? pair.Item2 : pair.Item1;
+                        leastPrivilegePairs.Add(toAdd);
+                    }
+                }
+                return leastPrivilegePairs;
             }
 
             return claims.Select(p => p.Permission).ToHashSet();

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Kibali
 {

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -59,9 +59,9 @@ namespace Kibali
                     {
                         errors.Add(new PermissionsError
                         {
-                            Path = this.Url,
+                            Path = Url,
                             ErrorCode = PermissionsErrorCode.DuplicatePathsetEntry,
-                            Message = string.Format(StringConstants.DuplicatePathsetEntryErrorMessage, permission, this.Url, schemeKey, supportedMethod),
+                            Message = string.Format(StringConstants.DuplicatePathsetEntryErrorMessage, permission, Url, schemeKey, supportedMethod),
                         });
                     }
                 }
@@ -135,9 +135,9 @@ namespace Kibali
                         {
                             duplicateErrors.Add(new PermissionsError
                             {
-                                Path = this.Url,
+                                Path = Url,
                                 ErrorCode = PermissionsErrorCode.DuplicatePathsetEntry,
-                                Message = string.Format(StringConstants.DuplicatePathsetEntryErrorMessage, permission, this.Url, newScheme.Key, supportedMethod),
+                                Message = string.Format(StringConstants.DuplicatePathsetEntryErrorMessage, permission, Url, newScheme.Key, supportedMethod),
                             });
                         }
                     }

--- a/src/kibali/ProtectedResource.cs
+++ b/src/kibali/ProtectedResource.cs
@@ -406,7 +406,7 @@ namespace Kibali
             }
             if (higherPrivilegedPairs.Count != 0)
             {
-                higher = string.Join(", ", higherPrivilegedPairs.OrderByDescending(x => x.Length));
+                higher = string.Join(", ", higherPrivilegedPairs.OrderBy(x => x));
             }
             else
             {

--- a/src/kibali/StringConstants.cs
+++ b/src/kibali/StringConstants.cs
@@ -9,4 +9,6 @@ public class StringConstants
     internal const string PermissionNotSupported = "Not supported.";
 
     internal const string PermissionNotAvailable = "Not available.";
+    
+    internal const string DuplicatePathsetEntryErrorMessage = "Duplicate pathset entry. Permission: '{0}' Path: '{1}' Scheme: '{2}' Method: '{3}' ";
 }

--- a/src/kibaliTool/KibaliTool.csproj
+++ b/src/kibaliTool/KibaliTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kibali</ToolCommandName>
-    <Version>0.22.0</Version>
+    <Version>0.23.0</Version>
     <PackageId>Microsoft.Graph.KibaliTool</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/src/kibaliTool/KibaliTool.csproj
+++ b/src/kibaliTool/KibaliTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>kibali</ToolCommandName>
-    <Version>0.23.0</Version>
+    <Version>0.24.0</Version>
     <PackageId>Microsoft.Graph.KibaliTool</PackageId>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/MicrosoftGraph/kibali</PackageProjectUrl>

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -337,9 +337,9 @@ public class DocumentationTests
         var expectedTable = @"
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Bar.Read and Foo.Read|Bar.Read and Foo.Write, Bar.Write and Foo.Write, Foo.Read and Foo.Write|
+|Delegated (work or school account)|Bar.Read and Foo.Read|Bar.Write and Foo.Write, Foo.Read and Foo.Write, Bar.Read and Foo.Write|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Bar.Read and Foo.Read|Bar.Read and Foo.Write, Bar.Write and Foo.Write, Foo.Read and Foo.Write|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+|Application|Bar.Read and Foo.Read|Bar.Write and Foo.Write, Foo.Read and Foo.Write, Bar.Read and Foo.Write|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         Assert.Equal(expectedTable, table);
     }

--- a/test/kibaliTests/DocumentationTests.cs
+++ b/test/kibaliTests/DocumentationTests.cs
@@ -185,7 +185,7 @@ public class DocumentationTests
 |:---|:---|:---|
 |Delegated (work or school account)|Bar.ReadWrite.OwnedBy and Foo.ReadWrite|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Bar.ReadWrite.OwnedBy and Foo.ReadWrite|Bar.ReadWrite.OwnedBy and Baz.ReadWrite, Bar.ReadWrite|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+|Application|Bar.ReadWrite.OwnedBy and Foo.ReadWrite|Bar.ReadWrite, Bar.ReadWrite.OwnedBy and Baz.ReadWrite|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         Assert.Equal(expectedTable, table);
     }
@@ -337,9 +337,9 @@ public class DocumentationTests
         var expectedTable = @"
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Bar.Read and Foo.Read|Bar.Write and Foo.Write, Foo.Read and Foo.Write, Bar.Read and Foo.Write|
+|Delegated (work or school account)|Bar.Read and Foo.Read|Bar.Read and Foo.Write, Bar.Write and Foo.Write, Foo.Read and Foo.Write|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Bar.Read and Foo.Read|Bar.Write and Foo.Write, Foo.Read and Foo.Write, Bar.Read and Foo.Write|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
+|Application|Bar.Read and Foo.Read|Bar.Read and Foo.Write, Bar.Write and Foo.Write, Foo.Read and Foo.Write|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 
         Assert.Equal(expectedTable, table);
     }
@@ -437,7 +437,7 @@ public class DocumentationTests
         var expectedTable = @"
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Baz.Read and Foo.Read|Foo.Read and Bar.Write, Foo.Read and Foo.Write, Foo.Read and Bar.Read|
+|Delegated (work or school account)|Baz.Read and Foo.Read|Foo.Read and Bar.Read, Foo.Read and Bar.Write, Foo.Read and Foo.Write|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
 |Application|Bar.Read and Foo.Read|Foo.Read and Bar.Write, Foo.Read and Foo.Write|".Replace("\r\n", string.Empty).Replace("\n", string.Empty);
 

--- a/test/kibaliTests/LeastPrivilegeTests.cs
+++ b/test/kibaliTests/LeastPrivilegeTests.cs
@@ -233,7 +233,6 @@ GET
                             },
                             Paths = {
                                 { "/foo",  "least=DelegatedWork,Application" },
-                                { "/bar",  null },
                                 { "/bar/{id}",  null },
                                 { "/bar/{id}/schmo",  null }
                             }


### PR DESCRIPTION
Duplicate pathset entries were resulting in some docs being rendered incorrectly. Fixes #85 and #87
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/89)