### PR TITLE
Revert making AuthorizationType Field mandatory.

### DIFF
--- a/specs/permissions-schema.json
+++ b/specs/permissions-schema.json
@@ -20,7 +20,6 @@
             "type": "object",
             "title": "Permission definition",
             "additionalProperties": false,
-            "required": ["authorizationType"],
             "properties": {
                 "authorizationType": {
                     "type": "string",


### PR DESCRIPTION
Revert on making the authorizationType field in permission json schema mandatory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/122)