### PR TITLE
Adding templateContext to releaseJob

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -20,6 +20,7 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -242,8 +243,16 @@ extends:
       dependsOn: build
       jobs:
       - deployment: deploy_kibaliTool
+        displayName: 'Deploy KibaliTool'
         dependsOn: []
         environment: nuget-org
+        templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+              - input: pipelineArtifact
+                artifactName: Nugets
+                targetPath: '$(Pipeline.Workspace)'
         strategy:
           runOnce:
             deploy:


### PR DESCRIPTION
Following this security [alert](https://vnext.s360.msftcloudes.com/blades/unifiedplatform?blade=KPI:41b084c4-5e50-42d9-854f-086d670244b9~SLA:3~AssignedTo:All~Forums:All~waves:All~Tab:Summary~_loc:UnifiedPlatform&peopleBasedNodes=karthikra_team;makangar_team&global=4:53679850-d579-40fc-a03c-995604d2df65)

And this ADO [item](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_workitems/edit/31798)
The releaseJob property has been added to the deployment step of the pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/137)