### PR TITLE
Updating pipeline download artifact step

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -252,22 +252,16 @@ extends:
             inputs:
               - input: pipelineArtifact
                 artifactName: Nugets
-                targetPath: '$(Pipeline.Workspace)'
+                targetPath: $(Build.ArtifactStagingDirectory)/Nugets
+              - input: pipelineArtifact
+                artifactName: Microsoft.Graph.Kibali-v$(kibaliToolversion)
+                targetPath: '$(Build.ArtifactStagingDirectory)/Microsoft.Graph.Kibali-v$(kibaliToolversion)'
         strategy:
           runOnce:
             deploy:
               pool:
                 vmImage: ubuntu-latest
               steps:
-              - task: DownloadPipelineArtifact@2
-                displayName: Download nupkg from artifacts
-                inputs:
-                  artifact: Nugets
-                  source: current
-              - task: DownloadPipelineArtifact@2
-                displayName: Download kibaliTool executable from artifacts
-                inputs:
-                  source: current
               - pwsh: |
                   $artifactName = Get-ChildItem -Path $(Pipeline.Workspace)\Nugets -Filter Microsoft.Graph.*.nupkg -recurse | select -First 1
                   $artifactVersion= $artifactName.Name -replace "Microsoft.Graph.Kibali", "" -replace ".nupkg", ""


### PR DESCRIPTION
Following the 1ES docs. The downloadArtifactStep was changed to use template context instead: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/inputs#input-syntax
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/139)