### PR TITLE
ci: update ESRP code signing to v6

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -117,7 +117,7 @@ extends:
             CredScan: false
             PoliCheck: true
         
-        - task: EsrpCodeSigning@5
+        - task: EsrpCodeSigning@6
           displayName: 'ESRP CodeSigning'
           inputs:
             ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'
@@ -179,7 +179,7 @@ extends:
         - pwsh: dotnet pack $(Build.SourcesDirectory)/src/kibaliTool/KibaliTool.csproj -o $(Build.ArtifactStagingDirectory) --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg
           displayName: 'pack KibaliTool'
         
-        - task: EsrpCodeSigning@5
+        - task: EsrpCodeSigning@6
           displayName: 'ESRP CodeSigning Nuget Packages'
           inputs:
             ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'


### PR DESCRIPTION
Updates ESRP code signing pipeline tasks from v5 to v6. v5 runs on Node16 and is getting deprecated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/187)