### PR TITLE
ci: restore packages from private Azure Artifacts feed

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -73,13 +73,36 @@ extends:
           inputs:
             versionSpec: '>=5.2.0'
             checkLatest: true
-        
+
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to Azure Artifacts'
+
+        - pwsh: |
+            @"
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+              </packageSources>
+            </configuration>
+            "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+          displayName: 'Create nuget.config (central feed)'
+
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet restore'
+          inputs:
+            command: restore
+            projects: '$(Build.SourcesDirectory)\kibali.sln'
+            feedsToUse: 'config'
+            nugetConfigPath: '$(Build.SourcesDirectory)/nuget.config'
+
         # Build the Product project
         - task: DotNetCoreCLI@2
           displayName: 'build'
           inputs:
             projects: '$(Build.SourcesDirectory)\kibali.sln'
-            arguments: '--configuration $(BuildConfiguration) --no-incremental'
+            arguments: '--configuration $(BuildConfiguration) --no-incremental --no-restore'
         
         # Run the Unit test
         - task: DotNetCoreCLI@2


### PR DESCRIPTION
# Description

Ports the ADO pipeline (`.azure-pipelines/ci-build.yml`) to restore NuGet packages from the private **`GraphDeveloperExperiences_Public`** Azure Artifacts feed, following the pattern established in [msgraph-sdk-dotnet's `ci-build.yml`](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/main/.azure-pipelines/ci-build.yml).

In the `build` job, immediately after the existing `NuGetToolInstaller` step:

1. **`NuGetAuthenticate@1`** — authenticates the build agent to Azure Artifacts.
2. **Create `nuget.config`** — generates a config with `<clear />` (removes nuget.org) and the single `GraphDeveloperExperiences_Public` feed source at `$(Build.SourcesDirectory)/nuget.config`.
3. **`dotnet restore`** — restores `kibali.sln` with `feedsToUse: config` and `nugetConfigPath` pointing at the generated config.
4. The **build** step now passes `--no-restore` so it uses the authenticated restore output. The `test` step already ran with `--no-build`.

> **Note:** requires the pipeline build identity to have read access to the `GraphDeveloperExperiences_Public` feed. The feed URL is hardcoded to match msgraph-sdk-dotnet's release pipeline; the `nuget.config` is generated at build time and not committed, so local builds are unaffected.

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## Testing Done

YAML syntax validated locally. Pipeline behavior can only be fully verified on an ADO run.

- [ ] `dotnet build` passes
- [ ] `dotnet test` passes

## Checklist

- [x] No breaking changes introduced
- [x] Documentation updated (if applicable) — N/A
- [ ] Tests added or updated for new functionality — N/A (CI config change)
- [x] Code follows existing project conventions
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/kibali/pull/188)